### PR TITLE
Add info about official API support for custom label text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ google-maps-utility-library-v3-markerwithlabel
 ### Purpose:
 
 Google code's hosting of http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerwithlabel/1.1.10/src/markerwithlabel.js as a resource no longer works. This project does not seem to have been forked anywhere yet (via this [list](http://googlemaps.github.io/libraries.html)). Therefore this lib is being published here to work with bower and npm.
+
+### Official API Support:
+
+Since August 2015, the official API [supports adding a single character as custom label text](http://googlegeodevelopers.blogspot.co.uk/2015/08/labels-meets-markers-with-google-maps.html) on top of a custom icon. For some cases, this may be sufficient. There is also a [maps API issue](https://code.google.com/p/gmaps-api-issues/issues/detail?id=8578) requesting the one char restriction be relaxed. This combined with the existing support for custom icons should help more people eliminate the need for the Marker With Label library. If possible please star that issue to encourage Google to fix it - thanks!


### PR DESCRIPTION
I'm trying to get people to support my issue to allow multi character label text in the official Google Maps API. I think this would allow many people to eliminate the need for Marker With Label. Would you be willing to add this info to the readme? 

Thanks!
